### PR TITLE
Fix auto reload and simplify argument handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Building on what we've learned from [DP Creator](https://github.com/opendp/dpcre
 ## Usage
 
 ```
-usage: dp-creator-ii [-h] [--csv CSV_PATH] [--unit UNIT_OF_PRIVACY] [--debug]
+usage: dp-creator-ii [-h] [--csv CSV_PATH] [--unit UNIT_OF_PRIVACY]
 
 DP Creator II makes it easier to get started with Differential Privacy.
 
@@ -24,8 +24,6 @@ options:
   --unit UNIT_OF_PRIVACY
                         Unit of privacy: How many rows can an individual
                         contribute?
-  --debug               Use during development for increased logging and auto-
-                        reload after code changes
 ```
 
 

--- a/dp_creator_ii/.gitignore
+++ b/dp_creator_ii/.gitignore
@@ -1,1 +1,0 @@
-config.json

--- a/dp_creator_ii/__init__.py
+++ b/dp_creator_ii/__init__.py
@@ -25,12 +25,6 @@ def get_parser():
         type=int,
         help="Unit of privacy: How many rows can an individual contribute?",
     )
-    parser.add_argument(
-        "--debug",
-        action="store_true",
-        help="Use during development for increased logging "
-        "and auto-reload after code changes",
-    )
     return parser
 
 
@@ -51,12 +45,7 @@ def main():  # pragma: no cover
         )
     )
 
-    run_app_kwargs = (
-        {}
-        if not args.debug
-        else {
-            "reload": True,
-            "log_level": "debug",
-        }
-    )
+    run_app_kwargs = {
+        "reload": True,
+    }
     shiny.run_app(launch_browser=True, **run_app_kwargs)

--- a/dp_creator_ii/__init__.py
+++ b/dp_creator_ii/__init__.py
@@ -3,7 +3,6 @@
 import os
 from pathlib import Path
 from argparse import ArgumentParser
-import json
 
 import shiny
 
@@ -11,7 +10,7 @@ import shiny
 __version__ = "0.0.1"
 
 
-def get_parser():
+def get_arg_parser():
     parser = ArgumentParser(description=__doc__)
     parser.add_argument(
         "--csv",
@@ -29,21 +28,12 @@ def get_parser():
 
 
 def main():  # pragma: no cover
-    parser = get_parser()
-    args = parser.parse_args()
+    # We call parse_args() again inside the app.
+    # We only call it here so "--help" is handled.
+    get_arg_parser().parse_args()
 
-    os.chdir(Path(__file__).parent)  # run_app() depends on the CWD.
-
-    # Just setting variables in a plain python module doesn't work:
-    # The new thread started for the server doesn't see changes.
-    Path("config.json").write_text(
-        json.dumps(
-            {
-                "csv_path": str(args.csv_path),
-                "unit_of_privacy": args.unit_of_privacy,
-            }
-        )
-    )
+    # run_app() depends on the CWD.
+    os.chdir(Path(__file__).parent)
 
     run_app_kwargs = {
         "reload": True,

--- a/dp_creator_ii/app.py
+++ b/dp_creator_ii/app.py
@@ -1,8 +1,6 @@
-import json
-from pathlib import Path
-
 from shiny import App, ui, reactive, render
 
+from dp_creator_ii import get_arg_parser
 from dp_creator_ii.template import make_notebook_py, make_script_py
 from dp_creator_ii.converters import convert_py_to_nb
 
@@ -55,12 +53,10 @@ app_ui = ui.page_bootstrap(
 
 
 def server(input, output, session):
-    config_path = Path(__file__).parent / "config.json"
-    config = json.loads(config_path.read_text())
-    config_path.unlink()
+    args = get_arg_parser().parse_args()
 
-    csv_path = reactive.value(config["csv_path"])
-    unit_of_privacy = reactive.value(config["unit_of_privacy"])
+    csv_path = reactive.value(args.csv_path)
+    unit_of_privacy = reactive.value(args.unit_of_privacy)
 
     @render.text
     def csv_path_text():

--- a/dp_creator_ii/tests/test_help.py
+++ b/dp_creator_ii/tests/test_help.py
@@ -5,7 +5,7 @@ import dp_creator_ii
 
 def test_help():
     help = (
-        dp_creator_ii.get_parser()
+        dp_creator_ii.get_arg_parser()
         .format_help()
         # argparse doesn't actually know the name of the script
         # and inserts the name of the running program instead.


### PR DESCRIPTION
- Fix #6
- Drop the `--debug` flag and make watching the filesystem the default, and keep the default log level. We can revisit this when there's a need.
- Move arg parsing down inside the app, and get rid of hacky `config.json`: `sys.argv` is accessible everywhere, so just wait to parse until the app has started.