### PR TITLE
Handle non-utf8 CSVs

### DIFF
--- a/dp_creator_ii/templates/context.py
+++ b/dp_creator_ii/templates/context.py
@@ -1,5 +1,5 @@
 context = dp.Context.compositor(
-    data=pl.scan_csv(CSV_PATH),
+    data=pl.scan_csv(CSV_PATH, encoding="utf8-lossy"),
     privacy_unit=dp.unit_of(contributions=UNIT),
     privacy_loss=dp.loss_of(epsilon=LOSS),
     split_by_weights=WEIGHTS,

--- a/dp_creator_ii/tests/test_csv.py
+++ b/dp_creator_ii/tests/test_csv.py
@@ -1,0 +1,26 @@
+import csv
+import polars as pl
+import polars.testing
+import tempfile
+import pytest
+
+
+@pytest.mark.parametrize("encoding", ["latin1", "utf8"])
+def test_csv_loading(encoding):
+    with tempfile.NamedTemporaryFile(
+        delete=False, mode="w", newline="", encoding=encoding
+    ) as fp:
+        # By default, would delete file on "close()";
+        # With "delete=False", clean up when exiting "with" instead.
+        old_lf = pl.DataFrame({"NAME": ["André"], "AGE": [42]}).lazy()
+
+        writer = csv.writer(
+            fp,
+        )
+        writer.writerow(["NAME", "AGE"])
+        for row in old_lf.collect().rows():
+            writer.writerow(row)
+        fp.close()
+
+        new_lf = pl.scan_csv(fp.name)
+        polars.testing.assert_frame_equal(old_lf, new_lf)

--- a/dp_creator_ii/tests/test_csv.py
+++ b/dp_creator_ii/tests/test_csv.py
@@ -8,19 +8,24 @@ import pytest
 @pytest.mark.parametrize("encoding", ["latin1", "utf8"])
 def test_csv_loading(encoding):
     with tempfile.NamedTemporaryFile(
-        delete=False, mode="w", newline="", encoding=encoding
+        delete_on_close=False, mode="w", newline="", encoding=encoding
     ) as fp:
-        # By default, would delete file on "close()";
-        # With "delete=False", clean up when exiting "with" instead.
         old_lf = pl.DataFrame({"NAME": ["André"], "AGE": [42]}).lazy()
 
-        writer = csv.writer(
-            fp,
-        )
+        writer = csv.writer(fp)
         writer.writerow(["NAME", "AGE"])
         for row in old_lf.collect().rows():
             writer.writerow(row)
         fp.close()
 
-        new_lf = pl.scan_csv(fp.name)
-        polars.testing.assert_frame_equal(old_lf, new_lf)
+        new_lf = pl.scan_csv(fp.name, encoding="utf8-lossy")
+        if encoding == "utf8":
+            polars.testing.assert_frame_equal(old_lf, new_lf)
+        if encoding != "utf8":
+            polars.testing.assert_frame_not_equal(old_lf, new_lf)
+            assert new_lf.collect().rows()[0] == ("Andr�", 42)
+            # If the file even has non-utf8 characters,
+            # they are probably not the only thing that distinguishes
+            # two strings that we want to group on.
+            # Besides grouping, we don't do much with strings,
+            # so this feels safe.

--- a/dp_creator_ii/tests/test_csv.py
+++ b/dp_creator_ii/tests/test_csv.py
@@ -7,6 +7,11 @@ import pytest
 
 @pytest.mark.parametrize("encoding", ["latin1", "utf8"])
 def test_csv_loading(encoding):
+    """
+    This isn't really a test of our code: rather, it demonstrates the pattern
+    we plan to follow. (Though if we do decide to require the encoding from
+    the user, or use chardet to sniff the encoding, that should be tested here.)
+    """
     with tempfile.NamedTemporaryFile(
         delete_on_close=False, mode="w", newline="", encoding=encoding
     ) as fp:

--- a/dp_creator_ii/tests/test_csv.py
+++ b/dp_creator_ii/tests/test_csv.py
@@ -12,16 +12,14 @@ def test_csv_loading(encoding):
     we plan to follow. (Though if we do decide to require the encoding from
     the user, or use chardet to sniff the encoding, that should be tested here.)
     """
-    with tempfile.NamedTemporaryFile(
-        delete_on_close=False, mode="w", newline="", encoding=encoding
-    ) as fp:
+    with tempfile.NamedTemporaryFile(mode="w", newline="", encoding=encoding) as fp:
         old_lf = pl.DataFrame({"NAME": ["André"], "AGE": [42]}).lazy()
 
         writer = csv.writer(fp)
         writer.writerow(["NAME", "AGE"])
         for row in old_lf.collect().rows():
             writer.writerow(row)
-        fp.close()
+        fp.flush()
 
         new_lf = pl.scan_csv(fp.name, encoding="utf8-lossy")
         if encoding == "utf8":

--- a/dp_creator_ii/tests/test_template.py
+++ b/dp_creator_ii/tests/test_template.py
@@ -21,7 +21,7 @@ def test_fill_template():
             }
         )
     )
-    assert f"data=pl.scan_csv('{fake_csv}')" in context_block
+    assert f"data=pl.scan_csv('{fake_csv}', encoding=\"utf8-lossy\")" in context_block
 
 
 def test_fill_template_unfilled_slots():


### PR DESCRIPTION
- Fix #8 (Added some notes about alternative approaches there.)

The proposal here is just to include `encoding="utf8-lossy"` when we read CSVs, and not even bother with trying to figure out the correct encoding, because it will usually not matter.