### PR TITLE
Improve handling of different encodings

### DIFF
--- a/dp_creator_ii/utils/csv_helper.py
+++ b/dp_creator_ii/utils/csv_helper.py
@@ -1,7 +1,12 @@
-import csv
+import polars as pl
 
 
 def read_field_names(csv_path):
-    with open(csv_path, newline="") as csv_handle:
-        reader = csv.DictReader(csv_handle)
-        return reader.fieldnames
+    # Polars is overkill, but it is more robust against
+    # variations in encoding than Python stdlib csv.
+    # However, it could be slow:
+    #
+    # > Determining the column names of a LazyFrame requires
+    # > resolving its schema, which is a potentially expensive operation.
+    lf = pl.scan_csv(csv_path)
+    return lf.collect_schema().names()

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,6 +1,6 @@
 import csv
 import polars as pl
-import polars.testing
+import polars.testing as pl_testing
 import tempfile
 import pytest
 from pathlib import Path
@@ -8,52 +8,54 @@ from pathlib import Path
 from dp_creator_ii.utils.csv_helper import read_field_names
 
 
-@pytest.mark.parametrize("encoding", ["utf8", "utf-8-sig"])
-def test_read_field_names(encoding):
-    with tempfile.NamedTemporaryFile(mode="w", newline="", encoding=encoding) as fp:
-        writer = csv.writer(fp)
-        field_names_written = ["abc", "ijk", "xyz"]
-        writer.writerow(field_names_written)
-        fp.flush()
+# @pytest.mark.parametrize("encoding", ["latin1", "utf8", "utf-8-sig"])
+# def test_read_field_names(encoding):
+#     with tempfile.NamedTemporaryFile(mode="w", newline="", encoding=encoding) as fp:
+#         writer = csv.writer(fp)
+#         field_names_written = ["abc", "ijk", "xyz"]
+#         writer.writerow(field_names_written)
+#         fp.flush()
 
-        field_names_read = read_field_names(fp.name)
-        assert field_names_written == field_names_read
+#         field_names_read = read_field_names(fp.name)
+#         assert field_names_written == field_names_read
 
 
-@pytest.mark.parametrize("encoding", ["latin1", "utf8"])
-def test_csv_loading(encoding):
-    """
-    This isn't really a test of our code: rather, it demonstrates the pattern
-    we plan to follow. (Though if we do decide to require the encoding from
-    the user, or use chardet to sniff the encoding, that should be tested here.)
-    """
-    with tempfile.NamedTemporaryFile(mode="w", newline="", encoding=encoding) as fp:
-        old_lf = pl.DataFrame({"NAME": ["André"], "AGE": [42]}).lazy()
+# We will not reference the encoding when reading:
+# We need to be robust against any input.
+@pytest.mark.parametrize("write_encoding", ["latin1", "utf8", "utf-8-sig"])
+def test_csv_loading(write_encoding):
+    with tempfile.NamedTemporaryFile(
+        mode="w", newline="", encoding=write_encoding
+    ) as fp:
+        write_lf = pl.DataFrame({"NAME": ["André"], "AGE": [42]}).lazy()
 
         writer = csv.writer(fp)
         writer.writerow(["NAME", "AGE"])
-        for row in old_lf.collect().rows():
+        for row in write_lf.collect().rows():
             writer.writerow(row)
         fp.flush()
 
-        # w/o "ignore_errors=True" it fails outright.
-        # We could ignore_errors:
-        new_default_lf = pl.scan_csv(fp.name, ignore_errors=True)
-        if encoding == "utf8":
-            polars.testing.assert_frame_equal(old_lf, new_default_lf)
-        if encoding != "utf8":
-            polars.testing.assert_frame_not_equal(old_lf, new_default_lf)
-            assert new_default_lf.collect().rows()[0] == (None, 42)
+        # NOT WHAT WE'RE DOING!
+        # w/o "ignore_errors=True" it fails outright for latin1.
+        read_lf = pl.scan_csv(fp.name)
+        if write_encoding == "latin1":
+            with pytest.raises(pl.exceptions.ComputeError):
+                pl_testing.assert_frame_equal(write_lf, read_lf)
 
-        # But we retain more information with utf8-lossy:
-        new_lossy_lf = pl.scan_csv(fp.name, encoding="utf8-lossy")
-        if encoding == "utf8":
-            polars.testing.assert_frame_equal(old_lf, new_lossy_lf)
-        if encoding != "utf8":
-            polars.testing.assert_frame_not_equal(old_lf, new_lossy_lf)
-            assert new_lossy_lf.collect().rows()[0] == ("Andr�", 42)
-            # If the file even has non-utf8 characters,
-            # they are probably not the only thing that distinguishes
-            # two strings that we want to group on.
-            # Besides grouping, we don't do much with strings,
-            # so this feels safe.
+        # ALSO NOT WHAT WE'RE DOING!
+        # w/ "ignore_errors=True" but w/o "utf8-lossy" it reads,
+        # but whole cell is empty if mis-encoded.
+        read_lf = pl.scan_csv(fp.name, ignore_errors=True)
+        if write_encoding == "latin1":
+            pl_testing.assert_frame_not_equal(write_lf, read_lf)
+            assert read_lf.collect().rows()[0] == (None, 42)
+
+        # THIS IS THE RIGHT PATTERN!
+        # Not perfect, but "utf8-lossy" retains as much info as possible.
+        read_lf = pl.scan_csv(fp.name, encoding="utf8-lossy")
+        if write_encoding == "latin1":
+            # Not equal, but the only differce is the "�".
+            pl_testing.assert_frame_not_equal(write_lf, read_lf)
+            assert read_lf.collect().rows()[0] == ("Andr�", 42)
+        else:
+            pl_testing.assert_frame_equal(write_lf, read_lf)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from dp_creator_ii.utils.csv_helper import read_field_names
 
 
-def test_read_field_names():
-    with tempfile.NamedTemporaryFile(mode="w", newline="", encoding="utf8") as fp:
+@pytest.mark.parametrize("encoding", ["utf8", "utf-8-sig"])
+def test_read_field_names(encoding):
+    with tempfile.NamedTemporaryFile(mode="w", newline="", encoding=encoding) as fp:
         writer = csv.writer(fp)
         field_names_written = ["abc", "ijk", "xyz"]
         writer.writerow(field_names_written)

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -9,9 +9,14 @@ from dp_creator_ii.utils.csv_helper import read_field_names
 
 
 def test_read_field_names():
-    csv_path = Path(__file__).parent / "fixtures" / "fake.csv"
-    field_names = read_field_names(csv_path)
-    assert field_names == ["student_id", "class_year", "hw_number", "grade"]
+    with tempfile.NamedTemporaryFile(mode="w", newline="", encoding="utf8") as fp:
+        writer = csv.writer(fp)
+        field_names_written = ["abc", "ijk", "xyz"]
+        writer.writerow(field_names_written)
+        fp.flush()
+
+        field_names_read = read_field_names(fp.name)
+        assert field_names_written == field_names_read
 
 
 @pytest.mark.parametrize("encoding", ["latin1", "utf8"])

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -27,10 +27,11 @@ def test_csv_loading(write_encoding):
     with tempfile.NamedTemporaryFile(
         mode="w", newline="", encoding=write_encoding
     ) as fp:
-        write_lf = pl.DataFrame({"NAME": ["André"], "AGE": [42]}).lazy()
+        data = {"NAME": ["André"], "AGE": [42]}
+        write_lf = pl.DataFrame(data).lazy()
 
         writer = csv.writer(fp)
-        writer.writerow(["NAME", "AGE"])
+        writer.writerow(data.keys())
         for row in write_lf.collect().rows():
             writer.writerow(row)
         fp.flush()
@@ -59,3 +60,7 @@ def test_csv_loading(write_encoding):
             assert read_lf.collect().rows()[0] == ("Andr�", 42)
         else:
             pl_testing.assert_frame_equal(write_lf, read_lf)
+
+        # Preceding lines are reading the whole DF via Polars.
+        field_names_read = read_field_names(fp.name)
+        assert field_names_read == list(data.keys())

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -3,21 +3,8 @@ import polars as pl
 import polars.testing as pl_testing
 import tempfile
 import pytest
-from pathlib import Path
 
 from dp_creator_ii.utils.csv_helper import read_field_names
-
-
-# @pytest.mark.parametrize("encoding", ["latin1", "utf8", "utf-8-sig"])
-# def test_read_field_names(encoding):
-#     with tempfile.NamedTemporaryFile(mode="w", newline="", encoding=encoding) as fp:
-#         writer = csv.writer(fp)
-#         field_names_written = ["abc", "ijk", "xyz"]
-#         writer.writerow(field_names_written)
-#         fp.flush()
-
-#         field_names_read = read_field_names(fp.name)
-#         assert field_names_written == field_names_read
 
 
 # We will not reference the encoding when reading:


### PR DESCRIPTION
This improves our handling of different encodings, but it also involves using polars to read data when we just need the column headers.

- Fix #79