### PR TITLE
.venv/bin/dp-creator-ii

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ playwright install
 Now install the application itself and run it:
 ```shell
 $ flit install --symlink
-$ dp-creator-ii
+$ .venv/bin/dp-creator-ii
 ```
 Your browser should open and connect you to the application.
 


### PR DESCRIPTION
Maybe this is just me, maybe there's something wrong with my Python environment, but `dp-creator-ii` isn't in my $PATH. I had to run it as `.venv/bin/dp-creator-ii`.