### PR TITLE
Two column layout: Graph expands to fit

### DIFF
--- a/WHAT-WE-LEARNED.md
+++ b/WHAT-WE-LEARNED.md
@@ -62,3 +62,7 @@ I've had to tweak the CSS a few times:
 
 The different flavors of "Shiny" are a bit of nuissance when trying to find examples.
 The maturity of Shiny for R means that the vast majority of the examples are for R, even with Python in the search. It would be nice if the docs site remembered that I only want to look at docs for Core.
+
+## Shiny docs could have better formatting
+
+- https://shiny.posit.co/py/api/core/ui.layout_columns.html: bullet list not rendered correctly.

--- a/dp_creator_ii/app/components/column_module.py
+++ b/dp_creator_ii/app/components/column_module.py
@@ -10,11 +10,12 @@ from dp_creator_ii.app.components.outputs import output_code_sample
 
 @module.ui
 def column_ui():  # pragma: no cover
+    width = "10em"  # Just wide enough so the text isn't trucated.
     return ui.layout_columns(
         [
-            ui.input_numeric("min", "Min", 0),
-            ui.input_numeric("max", "Max", 10),
-            ui.input_numeric("bins", "Bins", 10),
+            ui.input_numeric("min", "Min", 0, width=width),
+            ui.input_numeric("max", "Max", 10, width=width),
+            ui.input_numeric("bins", "Bins", 10, width=width),
             ui.input_select(
                 "weight",
                 "Weight",
@@ -24,8 +25,8 @@ def column_ui():  # pragma: no cover
                     4: "More accurate",
                 },
                 selected=2,
+                width=width,
             ),
-            output_code_sample("Column Definition", "column_code"),
         ],
         [
             # TODO: This doesn't need to be repeated: could just go once at the top.
@@ -35,14 +36,14 @@ def column_ui():  # pragma: no cover
                 "Your data file has not been read except to determine the columns."
             ),
             ui.output_plot("column_plot"),
+            output_code_sample("Column Definition", "column_code"),
         ],
         col_widths={
             # Controls stay roughly a constant width;
             # Graph expands to fill space.
-            "sm": (6, 6),
-            "md": (5, 7),
-            "lg": (4, 8),
-            "xl": (3, 9),
+            "sm": (4, 8),
+            "md": (3, 9),
+            "lg": (2, 10),
         },
     )
 

--- a/dp_creator_ii/app/components/column_module.py
+++ b/dp_creator_ii/app/components/column_module.py
@@ -30,12 +30,14 @@ def column_ui():  # pragma: no cover
         ],
         [
             # TODO: This doesn't need to be repeated: could just go once at the top.
+            # https://github.com/opendp/dp-creator-ii/issues/138
             ui.markdown(
                 "This simulation assumes a normal distribution "
                 "between the specified min and max. "
                 "Your data file has not been read except to determine the columns."
             ),
-            ui.output_plot("column_plot"),
+            ui.output_plot("column_plot", height="300px"),
+            # Make plot smaller than default: about the same size as the other column.
             output_code_sample("Column Definition", "column_code"),
         ],
         col_widths={

--- a/dp_creator_ii/app/components/column_module.py
+++ b/dp_creator_ii/app/components/column_module.py
@@ -10,28 +10,41 @@ from dp_creator_ii.app.components.outputs import output_code_sample
 
 @module.ui
 def column_ui():  # pragma: no cover
-    return [
-        ui.input_numeric("min", "Min", 0),
-        ui.input_numeric("max", "Max", 10),
-        ui.input_numeric("bins", "Bins", 10),
-        ui.input_select(
-            "weight",
-            "Weight",
-            choices={
-                1: "Less accurate",
-                2: "Default",
-                4: "More accurate",
-            },
-            selected=2,
-        ),
-        output_code_sample("Column Definition", "column_code"),
-        ui.markdown(
-            "This simulation assumes a normal distribution "
-            "between the specified min and max. "
-            "Your data file has not been read except to determine the columns."
-        ),
-        ui.output_plot("column_plot"),
-    ]
+    return ui.layout_columns(
+        [
+            ui.input_numeric("min", "Min", 0),
+            ui.input_numeric("max", "Max", 10),
+            ui.input_numeric("bins", "Bins", 10),
+            ui.input_select(
+                "weight",
+                "Weight",
+                choices={
+                    1: "Less accurate",
+                    2: "Default",
+                    4: "More accurate",
+                },
+                selected=2,
+            ),
+            output_code_sample("Column Definition", "column_code"),
+        ],
+        [
+            # TODO: This doesn't need to be repeated: could just go once at the top.
+            ui.markdown(
+                "This simulation assumes a normal distribution "
+                "between the specified min and max. "
+                "Your data file has not been read except to determine the columns."
+            ),
+            ui.output_plot("column_plot"),
+        ],
+        col_widths={
+            # Controls stay roughly a constant width;
+            # Graph expands to fill space.
+            "sm": (6, 6),
+            "md": (5, 7),
+            "lg": (4, 8),
+            "xl": (3, 9),
+        },
+    )
 
 
 @module.server

--- a/dp_creator_ii/app/css/styles.css
+++ b/dp_creator_ii/app/css/styles.css
@@ -1,5 +1,5 @@
 body {
-    margin: 1em;
+    margin: 2em;
 }
 
 #top_level_nav {


### PR DESCRIPTION
- Fix #131 
- Close #132 without fix: There is plenty of vertical space, and it's not immediately obvious from the docs how to get the label and the input on the same line.
- Demoing for Annie, and she would prefer a wider page margin, so I tweaked that. I still hope there is a "right" way to do this that extends the tab line to the edge of the window, but I don't have that solution right now.

I would also like to avoid repeating the warning above the graph, but that's more of a logic change, so don't worry about it right now.
- #138

Working with this part of the UI prompted me to file a new issue:
- #136

Time required: ~1 hour